### PR TITLE
remove extra lines in license header

### DIFF
--- a/host/src/tests/tztrng_test/tztrng_test.c
+++ b/host/src/tests/tztrng_test/tztrng_test.c
@@ -11,9 +11,7 @@
 * Unless required by applicable law or agreed to in writing, software         *
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT   *
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.            *
-*                                                                             *
-* See the License for the specific language governing permissions and         *
-* limitations under the License.                                              *
+*                                                                             *                                            *
 ******************************************************************************/
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
removed extra lines in license header that are not part of standard header