### PR TITLE
add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+#
+# files to be ignored
+#
+
+/host/lib
+/host/bin
+/host/src/tztrng_lib/build*
+/host/src/tests/tztrng_test/build*
+/tags
+/TAGS
+
+makelog.txt
+
+# cscope files
+cscope.*
+


### PR DESCRIPTION
to ignore some files, generated by build process or external editors.