### PR TITLE
Optimize TRNG lib stack memory usage

### DIFF
--- a/host/src/tztrng_lib/include/tztrng_defs.h
+++ b/host/src/tztrng_lib/include/tztrng_defs.h
@@ -55,7 +55,7 @@ typedef enum {
 } CCBool;
 
 /* Definitions of temp buffer for DMA */
-#define CC_RND_WORK_BUFFER_SIZE_WORDS 1528
+#define CC_RND_WORK_BUFFER_SIZE_WORDS 528/4
 
 /* The CRYS Random Generator Parameters  structure CCRndParams_t -
    structure containing the user given Parameters */
@@ -201,9 +201,6 @@ void LLF_RND_TurnOffTrng(void);
 CCError_t LLF_RND_GetFastestRosc( CCRndParams_t *trngParams_ptr, uint32_t *rosc_ptr/*in/out*/);
 CCError_t LLF_RND_GetRoscSampleCnt( uint32_t rosc, CCRndParams_t *pTrngParams);
 uint32_t LLF_RND_TRNG_RoscMaskToNum(uint32_t mask);
-
-#define CC_RND_ESTIM_BUFF_SIZE_WORDS            386 /*256+128+2*/
-#define CC_RND_SRC_BUFF_OFFSET_WORDS  CC_RND_ESTIM_BUFF_SIZE_WORDS
 
 #define CC_RND_NOT_INSTANTIATED             	0UL
 #define CC_RND_INSTANTIATED                	    1UL

--- a/host/src/tztrng_lib/llf_rnd_trng90b.c
+++ b/host/src/tztrng_lib/llf_rnd_trng90b.c
@@ -167,7 +167,7 @@ static CCError_t startTrngHW(
     /*--------------------------------------------------------------*/
     /* 2. Restart the TRNG and set  parameters              */
     /*--------------------------------------------------------------*/
-	
+
     /* in order to verify that the reset has completed the sample count need to be verified */
     do {
         /* set sampling ratio (rng_clocks) between consequtive bits */
@@ -234,7 +234,7 @@ static CCError_t getTrngSource(
 
     /* Set source RAM address with offset 8 bytes from sourceOut address in
       order to remain empty bytes for CC operations */
-    *sourceOut_ptr_ptr = rndWorkBuff_ptr + CC_RND_SRC_BUFF_OFFSET_WORDS;
+    *sourceOut_ptr_ptr = rndWorkBuff_ptr;
     ramAddr = *sourceOut_ptr_ptr;
 
     /* init to 0 for FE mode */


### PR DESCRIPTION
- Head room for TRNG work buffer is not needed
- Reduce work buffer size to accomodate
  CC_CONFIG_TRNG90B_AMOUNT_OF_BYTES_STARTUP (the max required bytes)