### PR TITLE
Optimize stack memory usage

### DIFF
--- a/host/src/tztrng_lib/include/config_trng90b.h
+++ b/host/src/tztrng_lib/include/config_trng90b.h
@@ -22,30 +22,6 @@
 This file should be updated according to the characterization process.
 */
 
-/*
-Requirements:
-- Required entropy = 384 bits
-
-Default values for Zynq FPGA:
-- entropy per bit = 0.5
-*/
-
-/* amount of bytes for the required entropy bits = ROUND_UP(ROUND_UP(((required entropy bits)/(entropy per bit)), 1024), (EHR width in bytes)) / 8
-   (multiple of the window size 1024 bits and multiple of the EHR width 192 bits) */
-#define CC_CONFIG_TRNG90B_AMOUNT_OF_BYTES                      144  /* ROUND_UP(ROUND_UP((384/0.5), 1024), 192) / 8 = 144 */
-
-/*** NIST SP 800-90B (2nd Draft) 4.4.1 ***/
-/* C = ROUND_UP(1+(-log(W)/H)), W = 2^(-40), H=(entropy per bit) */
-#define CC_CONFIG_TRNG90B_REPETITION_COUNTER_CUTOFF            81  /* ROUND_UP(1+(40/0.5)) = 81 */
-
-/*** NIST SP 800-90B (2nd Draft) 4.4.2 ***/
-/* C =CRITBINOM(W, power(2,(-H)),1-a), W = 1024, a = 2^(-40), H=(entropy per bit) */
-#define CC_CONFIG_TRNG90B_ADAPTIVE_PROPORTION_CUTOFF           823      /* =CRITBINOM(1024, power(2,(-0.5)),1-2^(-40)) */
-
-/*** For Startup Tests ***/
-/* amount of bytes for the startup test = 528 (at least 4096 bits (NIST SP 800-90B (2nd Draft) 4.3.12) = 22 EHRs = 4224 bits) */
-#define CC_CONFIG_TRNG90B_AMOUNT_OF_BYTES_STARTUP              528
-
 /* sample count for each ring oscillator */
 /* for unallowed rosc, sample count = 0 */
 #define CC_CONFIG_SAMPLE_CNT_ROSC_1		200

--- a/host/src/tztrng_lib/llf_rnd_fetrng.c
+++ b/host/src/tztrng_lib/llf_rnd_fetrng.c
@@ -152,7 +152,7 @@ CCError_t LLF_RND_GetTrngSource(
 
     /* Set source RAM address with offset 8 bytes from sourceOut address in
       order to remain empty bytes for CC operations */
-    *sourceOut_ptr_ptr = rndWorkBuff_ptr + CC_RND_SRC_BUFF_OFFSET_WORDS;
+    *sourceOut_ptr_ptr = rndWorkBuff_ptr;
     ramAddr = *sourceOut_ptr_ptr;
     /* init to 0 for FE mode */
     *sourceOutSize_ptr = 0;

--- a/host/src/tztrng_lib/llf_rnd_trng90b.c
+++ b/host/src/tztrng_lib/llf_rnd_trng90b.c
@@ -167,7 +167,7 @@ static CCError_t startTrngHW(
     /*--------------------------------------------------------------*/
     /* 2. Restart the TRNG and set  parameters              */
     /*--------------------------------------------------------------*/
-	
+
     /* in order to verify that the reset has completed the sample count need to be verified */
     do {
         /* set sampling ratio (rng_clocks) between consequtive bits */
@@ -234,7 +234,7 @@ static CCError_t getTrngSource(
 
     /* Set source RAM address with offset 8 bytes from sourceOut address in
       order to remain empty bytes for CC operations */
-    *sourceOut_ptr_ptr = rndWorkBuff_ptr + CC_RND_SRC_BUFF_OFFSET_WORDS;
+    *sourceOut_ptr_ptr = rndWorkBuff_ptr;
     ramAddr = *sourceOut_ptr_ptr;
 
     /* init to 0 for FE mode */


### PR DESCRIPTION
- down size work buffer from 1528 to 132 words
- remove unnecessary head room
- move 90B macros to generic header so
  CC_RND_WORK_BUFFER_SIZE_WORDS can refer to