### PR TITLE
Add mbed OS compilation support

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,0 +1,10 @@
+host/src/tests/tztrng_test/tztrng_test.c
+host/src/tests/tztrng_test/pal/tztrng_test_pal_api.h
+host/src/tests/tztrng_test/pal/linux/tztrng_test_pal.c
+host/src/tests/tztrng_test/pal/linux/tztrng_test_pal.h
+host/src/tests/tztrng_test/pal/freertos/tztrng_test_pal.c
+host/src/tests/tztrng_test/pal/freertos/tztrng_test_pal.h
+host/src/tests/tztrng_test/tztrng_test.h
+host/src/tests/tztrng_test/tztrng_test_arm.c
+host/src/tztrng_lib/llf_rnd_fetrng.c
+host/src/tztrng_lib/include/config_fetrng.h

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Containing:
 * Software Integrator's Manual   (trustzone_true_random_number_generator_software_integrators_manual_101049_0000_00_en.pdf)
 
 ARM TrustZone TRNG supports 32-bit systems.
+The `.mbedignore` file allows the driver to be used as it is for TRNG implementation in mbed OS. That file will make it work under 800-90B TRNG mode.
 
 ## License 
 


### PR DESCRIPTION
This patch adds a .mbedignore file that will allow successfull
compilation of this driver with mbed OS tools. This file will make mbed
OS ignores the FR TRNG related files and then use it under 800-90B mode.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>