### PR TITLE
adding arm-armclang to use ACC6

### DIFF
--- a/host/Makefile.defs
+++ b/host/Makefile.defs
@@ -68,7 +68,8 @@ ARCH_SUPPORTED = powerpc arm arm64 i686 x86 x86_64 x86win
 # x86win - compilation for x86 Windows, using MinGW toolchain.
 
 # default ARCH
-ARCH ?= powerpc
+ARCH ?= arm
+CROSS_COMPILE ?= arm-none-eabi-
 export ARCH
 #$(info ARCH=$(ARCH))
 
@@ -92,35 +93,47 @@ ifeq ($(ARCH),arm)
 	# Same requirement for arm-eabi (bare metal) due to use of RTOS (private) libc implementation
 	CFLAGS += $(if $(filter arm-eabi-,$(CROSS_COMPILE)),-ffreestanding)
 	ARCH_ENDIAN = LITTLE
-ifeq ($(CROSS_COMPILE),arm-bcm2708hardfp-linux-gnueabi-)
+	ifeq ($(CROSS_COMPILE),arm-bcm2708hardfp-linux-gnueabi-)
         # RaspberryPi (ARM11/ARMv6) support
         $(info Assuming build for RaspberryPi)
         CFLAGS += -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s
-else
-        ifeq ($(CROSS_COMPILE),arm-none-eabi-)
+	else
+    	ifeq ($(CROSS_COMPILE),arm-none-eabi-)
             # For arm-none-eabi assume cortex-m3
             ARM_CPU ?= cortex-m3
             CFLAGS += -mthumb 
-	    TEE_OS = no_os
-	endif
-	ifeq ($(CROSS_COMPILE),arm-ds5)
-	    ARM_CPU ?= $(CORTEX)
-	    CFLAGS += --thumb
+	    	TEE_OS ?= no_os
+		endif
+		ifeq ($(CROSS_COMPILE),arm-ds5)
+			# For arm-ds5 assume cortex-m3
+	    	ARM_CPU ?= cortex-m3
+	    	CFLAGS += --thumb
+			TEE_OS ?= no_os
+        endif
+		ifeq ($(CROSS_COMPILE),arm-armclang)
+			# For arm-armclang assume cortex-m33
+	    	ARM_CPU ?= cortex-m33
+	    	CFLAGS += -mthumb
+			TEE_OS ?= no_os
         endif
         # For arm-eabi- assume a15, otherwise assume a9 (zynq7000)
         ARM_CPU ?= $(if $(filter arm-eabi-,$(CROSS_COMPILE)),cortex-a15,cortex-a9)
-ifeq ($(filter arm arm-ds5 ,$(CROSS_COMPILE)),$(CROSS_COMPILE))
-	CFLAGS += --cpu $(ARM_CPU) --littleend
-else
-        CFLAGS += -mcpu=$(ARM_CPU)
-endif
+		ifeq ($(filter arm arm-ds5 arm-armclang,$(CROSS_COMPILE)),$(CROSS_COMPILE))
+			ifeq ($(CROSS_COMPILE),arm-armclang)
+				CFLAGS += -mcpu=$(ARM_CPU) --target=arm-arm-none-eabi 
+			else
+				CFLAGS += --cpu $(ARM_CPU) --littleend
+			endif
+		else
+        	CFLAGS += -mcpu=$(ARM_CPU)
+		endif
         CFLAGS += $(if $(filter arm-eabi-,$(CROSS_COMPILE)),-DARCH_ARM -DARM_CPU_CORTEX_A15=1)
-endif
+	endif
 
-# for optee_os
-ifeq ($(CROSS_COMPILE),arm-linux-gnueabihf-)
+	# for optee_os
+	ifeq ($(CROSS_COMPILE),arm-linux-gnueabihf-)
         CFLAGS += -mfloat-abi=soft
-endif #arm-linux-gnueabihf-
+	endif #arm-linux-gnueabihf-
 
 endif #arm
 
@@ -139,14 +152,16 @@ ifeq ($(ARCH),x86win)
 	CROSS_COMPILE ?= i586-mingw32msvc-
 endif
 
-ifeq ($(filter arm arm-dsm- arm-ds5 ,$(CROSS_COMPILE)),$(CROSS_COMPILE))
-CC_DEF = 1
-CC = armcc
-LD = armcc
-AR = armar
-ifneq ($(CROSS_COMPILE),arm-ds5)
-override TEE_OS = no_os
-endif
+ifeq ($(filter arm arm-dsm- arm-ds5 arm-armclang,$(CROSS_COMPILE)),$(CROSS_COMPILE))
+	CC_DEF = 1
+	AR = armar
+	ifeq ($(CROSS_COMPILE),arm-armclang)
+		CC = armclang
+		LD = armclang
+	else
+		CC = armcc
+		LD = armcc
+	endif
 endif
 
 # subfolder for compilation/generation outcome/objects/binaries

--- a/host/Makefile.rules
+++ b/host/Makefile.rules
@@ -31,6 +31,10 @@ else ifeq ($(CROSS_COMPILE),arm-ds5)
 MM = --mm
 CFLAGS += -D__ARM_DS5__ #--strict --strict_warnings
 ARFLAGS = -rcs
+else ifeq ($(CROSS_COMPILE),arm-armclang)
+MM = -M
+CFLAGS += -D__ARM_DS5__ #--strict --strict_warnings
+ARFLAGS = -rcs
 else ifeq ($(CROSS_COMPILE),arm)
 CFLAGS += -D__ARM_DS__ --c99 --strict --strict_warnings
 ARFLAGS = -rcs
@@ -46,8 +50,10 @@ CFLAGS += -Wwrite-strings
 CFLAGS += -Wswitch-default
 CFLAGS += -Wunreachable-code
 CFLAGS += -Winit-self
+ifneq ($(CROSS_COMPILE),arm-armclang)
 CFLAGS += -Wjump-misses-init
 CFLAGS += -Wlogical-op
+endif
 CFLAGS += -Wmissing-field-initializers
 CFLAGS += -Werror=undef
 CFLAGS += -Werror -Wfatal-errors

--- a/host/src/tests/tztrng_test/Makefile
+++ b/host/src/tests/tztrng_test/Makefile
@@ -1,10 +1,10 @@
 HOST_PROJ_ROOT ?= $(shell pwd)/../../..
 
-# this section is normaly defined by hosr/src/config. Since this makefile is the only one published we need to define these varainbles here
-ifeq ($(CROSS_COMPILE),$(filter $(CROSS_COMPILE),arm-ds5 arm-none-eabi-))
-TEE_OS = freertos
-TEST_BOARD = mps2+
-TEST_PRODUCT = cc3x
+# this section is normaly defined by host/src/config. Since this makefile is the only one published we need to define these varainbles here
+ifeq ($(CROSS_COMPILE),$(filter $(CROSS_COMPILE),arm-ds5 arm-armclang arm-none-eabi-))
+TEE_OS := freertos
+TEST_BOARD := mps2+
+TEST_PRODUCT := cc3x
 else 
 # TEE_OS = linux // Do not overwrite TEE_OS in case of linux values
 TEST_BOARD = zynq


### PR DESCRIPTION
Greeting from Arm.JPN office. Arm genuine compiler is now moving to armclang from ACC version.6(armcc to armclang). To support the latest tool chain, just adding "CROSS_COMPILE=arm-armclang" option in makefiles, as well as some indent/syntax changes. 

I don't have FreeRTOS env so I could not apply the validation test, but comparing disasm from fromelf -c libcc_tztrng.a, and it seems everything is ok in original swich at "CROSS_COMPILE=arm-none-eabi-" and "CROSS_COMPILE=arm-ds5".

Also setting default architecture to arm(Line71: ARCH ?= arm) of cause!