### PR TITLE
Add no_os support in integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ This release contains the ARM TrustZone TRNG software.
 
 * To be run on an Ubuntu 14.04 LTS system host for building. 
 
-* gcc version 4.7.3 or arm-ds5 compiler are in your PATH.
+* gcc version 4.7.3, arm-ds5 or armclang compiler are in your PATH.
 
 * If using Linux as a host on the H/W, configure the KERNEL_DIR environment variable to point to your Linux (s).
 
-* The target is running Linux kernel 4.4 or FreeRTOS.
+* The target is running Linux kernel 4.4, FreeRTOS or bare-matal OS.
 
 Download the software bundle from https://github.com/ARM-software/TZ-TRNG.
 
@@ -50,15 +50,24 @@ Download the software bundle from https://github.com/ARM-software/TZ-TRNG.
 * For a target hw system running FreeRTOS:
 ```bash
    export KERNEL_DIR=/path/to/freertos
+   export TEE_OS=freertos
 ```
 or
 
 * For a target hw system running linux:
 ```bash
    export KERNEL_DIR=/path/to/linux
+   export TEE_OS=linux
+```
+or
+
+* For a target hw system running bare-matel OS:
+```bash
+   export KERNEL_DIR=
+   export TEE_OS=no_os
 ```				
   
-**Step 3**: Build all the binaries (common for FreeRTOS and Linux):
+**Step 3**: Build all the binaries (common for FreeRTOS, Linux and bare-matel OS):
 ```bash
    cd /path/to/tztrng
    make -C host/src/tztrng_lib/ clean
@@ -74,6 +83,7 @@ The tztrng library is located in:
 The integration test executable is located in the following path:
    - When compiling with gcc: host/bin/tztrng_test.
    - When compiling with armcc: host/lib/libtztrng_test.a.
+   - When compiling with armclang: host/lib/libtztrng_test.a.
 
 
 **Step 4**: Deploy:
@@ -85,6 +95,14 @@ The integration test executable is located in the following path:
   ```
 
 * For a target hw system running FreeRTOS:
+
+  ```bash
+     cp host/lib/libcc_tztrng.a /path/to/your/library/folder
+     cp host/lib/libtztrng_test.a /path/to/your/library/folder
+     cp host/src/tests/tztrng_test/tztrng_test.h /path/to/includes
+  ```
+
+* For a target hw system running bare-matel OS:
 
   ```bash
      cp host/lib/libcc_tztrng.a /path/to/your/library/folder

--- a/host/proj.cfg
+++ b/host/proj.cfg
@@ -1,6 +1,9 @@
 # Top-level project configuration for stand alone TRNG development
 PROJ_NAME = tztrng
 
+TEE_OS ?= no_os
+TEST_BOARD ?= mps2+
+
 HOST_LIBNAME = tztrng_lib
 PROJ_TARGETS += tztrng_lib
 
@@ -11,5 +14,4 @@ TZTRNG_HW_VERSION = 0xFF
 # FW images configuration
 FW_VER_MAJOR = 1
 FW_VER_MINOR = 0
-FW_VER_PATCH = 0 
-
+FW_VER_PATCH = 0

--- a/host/src/tests/tztrng_test/Makefile
+++ b/host/src/tests/tztrng_test/Makefile
@@ -2,7 +2,6 @@ HOST_PROJ_ROOT ?= $(shell pwd)/../../..
 
 # this section is normaly defined by hosr/src/config. Since this makefile is the only one published we need to define these varainbles here
 ifeq ($(CROSS_COMPILE),$(filter $(CROSS_COMPILE),armcc arm-none-eabi- armclang))
-TEE_OS = freertos
 TEST_BOARD = mps2+
 TEST_PRODUCT = cc3x
 else 
@@ -37,6 +36,11 @@ SOURCES_tztrng_test += tztrng_test_arm.c
 SOURCES_tztrng_test += $(filter-out board_configs.c, $(PAL_SOURCES))
 endif # pal
 endif # freertos
+
+# This specific test under no_os
+ifeq ($(TEE_OS),$(filter $(TEE_OS),no_os))
+
+endif
 
 # Sources
 SOURCES_tztrng_test += tztrng_test.c 

--- a/host/src/tests/tztrng_test/pal/no_os/tztrng_test_pal.c
+++ b/host/src/tests/tztrng_test/pal/no_os/tztrng_test_pal.c
@@ -1,0 +1,58 @@
+/******************************************************************************
+ * Copyright (c) 2017-2017, ARM, All Rights Reserved                           *
+ * SPDX-License-Identifier: Apache-2.0                                         *
+ *                                                                             *
+ * Licensed under the Apache License, Version 2.0 (the "License");             *
+ * you may not use this file except in compliance with the License.            *
+ *                                                                             *
+ * You may obtain a copy of the License at                                     *
+ * http://www.apache.org/licenses/LICENSE-2.0                                  *
+ *                                                                             *
+ * Unless required by applicable law or agreed to in writing, software         *
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT   *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.            *
+ *                                                                             *
+ * See the License for the specific language governing permissions and         *
+ * limitations under the License.                                              *
+ ******************************************************************************/
+
+#include "tztrng_test_pal.h"
+#include <stdlib.h>
+
+void tztrngTest_pal_unmapCcRegs(unsigned long regBase)
+{
+	if (regBase == 0)
+		regBase = 0;
+
+	return;
+}
+
+unsigned long tztrngTest_pal_mapCcRegs(unsigned long hwBase)
+{
+	return hwBase;
+}
+
+void *tztrngTest_pal_malloc(size_t size)
+{
+	return (void *)malloc(size);
+}
+
+void tztrngTest_pal_free(void *pvAddress)
+{
+	free(pvAddress);
+}
+
+int tztrngTest_pal_dumpData(unsigned char *large_buf, size_t outputlen)
+{
+	unsigned int i;
+
+	printf("data: ");
+
+	for (i = 0; i < outputlen; ++i) {
+		printf("%02x ", large_buf[i]);
+	}
+
+	printf("\n");
+
+	return 0;
+}

--- a/host/src/tests/tztrng_test/pal/no_os/tztrng_test_pal.h
+++ b/host/src/tests/tztrng_test/pal/no_os/tztrng_test_pal.h
@@ -1,0 +1,26 @@
+/******************************************************************************
+ * Copyright (c) 2017-2017, ARM, All Rights Reserved                           *
+ * SPDX-License-Identifier: Apache-2.0                                         *
+ *                                                                             *
+ * Licensed under the Apache License, Version 2.0 (the "License");             *
+ * you may not use this file except in compliance with the License.            *
+ *                                                                             *
+ * You may obtain a copy of the License at                                     *
+ * http://www.apache.org/licenses/LICENSE-2.0                                  *
+ *                                                                             *
+ * Unless required by applicable law or agreed to in writing, software         *
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT   *
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.            *
+ *                                                                             *
+ * See the License for the specific language governing permissions and         *
+ * limitations under the License.                                              *
+ ******************************************************************************/
+
+#ifndef _TZTRNG_TEST_HAL_H_
+#define _TZTRNG_TEST_HAL_H_
+
+#include <stdio.h>
+
+#define TZTRNG_PRINTF(format, ...)		printf(format, ##__VA_ARGS__)
+
+#endif //_TZTRNG_TEST_HAL_H_


### PR DESCRIPTION
Variable TEE_OS indicates which platform is used to integrate.
Freertos, Linux and bare OS are supported.
While the platform is freertos,
    use command "make -C host/src/tests/tztrng_test TEE_OS=freertos"
While the platform is Linux,
    use command "make -C host/src/tests/tztrng_test TEE_OS=linux"
While it is bare OS,
    use command "make -C host/src/tests/tztrng_test TEE_OS=no_os"
    or "make -C host/src/tests/tztrng_test"
Default, the integration platform is no_os